### PR TITLE
Allows input Hash (vs JSON)

### DIFF
--- a/json/tbd_seb_n2.json
+++ b/json/tbd_seb_n2.json
@@ -1,7 +1,8 @@
 {
   "schema": "https://github.com/rd2/tbd/blob/master/tbd.schema.json",
   "description": "testing JSON surface KHI entries",
-  "psis": [{
+  "psis": [
+    {
       "id": "good",
       "parapet": 0.5,
       "party": 0.9
@@ -17,7 +18,8 @@
       "grade": 0.45
     }
   ],
-  "khis": [{
+  "khis": [
+    {
       "id": "column",
       "point": 0.5
     },
@@ -26,16 +28,19 @@
       "point": 0.5
     }
   ],
-  "surfaces": [{
-    "id": "Entryway  Wall 5",
-    "khis": [{
-        "id": "column",
-        "count": 3
-      },
-      {
-        "id": "support",
-        "count": 4
-      }
-    ]
-  }]
+  "surfaces": [
+    {
+      "id": "Entryway  Wall 5",
+      "khis": [
+        {
+          "id": "column",
+          "count": 3
+        },
+        {
+          "id": "support",
+          "count": 4
+        }
+      ]
+    }
+  ]
 }

--- a/lib/measures/tbd/measure.xml
+++ b/lib/measures/tbd/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>tbd_measure</name>
   <uid>8890787b-8c25-4dc8-8641-b6be1b6c2357</uid>
-  <version_id>3e0bc642-b37c-488f-96d5-e73f4c6d432b</version_id>
-  <version_modified>20221020T205858Z</version_modified>
+  <version_id>4501c26f-1cd4-45d8-8f0e-f1ea907c27df</version_id>
+  <version_modified>20221125T130635Z</version_modified>
   <xml_checksum>99772807</xml_checksum>
   <class_name>TBDMeasure</class_name>
   <display_name>Thermal Bridging and Derating - TBD</display_name>
@@ -439,22 +439,22 @@
       <checksum>36FA11E3</checksum>
     </file>
     <file>
-      <filename>ua.rb</filename>
+      <filename>geo.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>7264CA34</checksum>
+      <checksum>D999D942</checksum>
     </file>
     <file>
       <filename>psi.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>F31F865A</checksum>
+      <checksum>AFC8A549</checksum>
     </file>
     <file>
-      <filename>geo.rb</filename>
+      <filename>ua.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>D999D942</checksum>
+      <checksum>B39B3BB0</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/tbd/resources/psi.rb
+++ b/lib/measures/tbd/resources/psi.rb
@@ -205,7 +205,7 @@ module TBD
         rimjoist:      0.300, # *
         parapet:       0.325, # *
         fenestration:  0.200, # *
-        corner:        0.300, # ** "regular (BETBG)", adj. for ext. dimensions
+        corner:        0.300, # ** not explicitely stated
         balcony:       0.500, # *
         party:         0.450, # *
         grade:         0.450, # *
@@ -219,7 +219,7 @@ module TBD
         rimjoist:      0.850, # *
         parapet:       0.800, # *
         fenestration:  0.500, # *
-        corner:        0.850, # ** ... not stated
+        corner:        0.850, # ** not explicitely stated
         balcony:       1.000, # *
         party:         0.850, # *
         grade:         0.850, # *
@@ -569,16 +569,21 @@ module TBD
     return mismatch("argh", s, Hash, mth, DBG, ipt)      unless argh.is_a?(Hash)
     return hashkey("argh", argh, opt, mth, DBG, ipt)     unless argh.key?(opt)
 
-    argh[:io_path]     = nil unless argh.key?(:io_path)
+    argh[:io_path    ] = nil unless argh.key?(:io_path)
     argh[:schema_path] = nil unless argh.key?(:schema_path)
-    pth = argh[:io_path]
+
+    pth = argh[:io_path    ]
     sch = argh[:schema_path]
 
-    if pth
-      return empty("JSON file", mth, FTL, ipt) unless File.size?(pth)
-      io = File.read(pth)
-      io = JSON.parse(io, symbolize_names: true)
-      return mismatch("io", io, Hash, mth, FTL, ipt) unless io.is_a?(Hash)
+    if pth && (pth.is_a?(String) || pth.is_a?(Hash))
+      if pth.is_a?(Hash)
+        io = pth
+      else
+        return empty("JSON file", mth, FTL, ipt) unless File.size?(pth)
+        io = File.read(pth)
+        io = JSON.parse(io, symbolize_names: true)
+        return mismatch("io", io, Hash, mth, FTL, ipt) unless io.is_a?(Hash)
+      end
 
       # Schema validation is not yet supported in the OpenStudio Application.
       # We nonetheless recommend that users rely on the json-schema gem, or an

--- a/lib/measures/tbd/resources/ua.rb
+++ b/lib/measures/tbd/resources/ua.rb
@@ -62,30 +62,33 @@ module TBD
     return zero("'#{id}': net area (m2)", mth, ERR, res)      unless area > TOL
 
     # First, calculate initial layer RSi to initially meet Ut target.
-    rt    = 1 / ut                      #                 target construction Rt
-    ro    = rsi(lc, film)               #                current construction Ro
-    new_r = lyr[:r] + (rt - ro)         #              new, un-derated layer RSi
-    new_u = 1 / new_r
+    rt     = 1 / ut                      #                target construction Rt
+    ro     = rsi(lc, film)               #               current construction Ro
+    new_r  = lyr[:r] + (rt - ro)         #             new, un-derated layer RSi
+    new_u  = 1 / new_r
 
     # Then, uprate (if possible) to counter expected thermal bridging effects.
-    u_psi = hloss / area                #                         from psi & khi
-    new_u = new_u - u_psi               # uprated layer USi to counter psi & khi
-    new_r = 1 / new_u                   # uprated layer RSi to counter psi & khi
+    u_psi  = hloss / area               #                         from psi & khi
+    new_u -= u_psi                      # uprated layer USi to counter psi & khi
+    new_r  = 1 / new_u                  # uprated layer RSi to counter psi & khi
 
     return zero("'#{id}': new Rsi", mth, ERR, res)          unless new_r > 0.001
-    loss  = 0.0                         # residual heatloss (not assigned) [W/K]
+
+    loss   = 0.0                        # residual heatloss (not assigned) [W/K]
 
     if lyr[:type] == :massless
       m     = lc.getLayer(lyr[:index]).to_MasslessOpaqueMaterial
       return  invalid("'#{id}' massless layer?", mth, 0)             if m.empty?
+
       m     = m.get.clone(model).to_MasslessOpaqueMaterial.get
               m.setName("#{id} uprated")
       new_r = 0.001                                         unless new_r > 0.001
       loss  = (new_u - 1 / new_r) * area                    unless new_r > 0.001
               m.setThermalResistance(new_r)
     else                                                     # type == :standard
-      m       = lc.getLayer(lyr[:index]).to_StandardOpaqueMaterial
+      m     = lc.getLayer(lyr[:index]).to_StandardOpaqueMaterial
       return  invalid("'#{id}' standard layer?", mth, 0)             if m.empty?
+
       m     = m.get.clone(model).to_StandardOpaqueMaterial.get
               m.setName("#{id} uprated")
       k     = m.thermalConductivity
@@ -108,10 +111,12 @@ module TBD
 
       ok = m.setThickness(d)
       return invalid("Can't uprate '#{id}': > 3m", mth, 0, ERR, res)   unless ok
+
       m.setThermalConductivity(k)                                          if ok
     end
 
     return invalid("", mth, 0, ERR, res) unless m
+
     lc.setLayer(lyr[:index], m)
     uo = 1 / rsi(lc, film)
 
@@ -187,6 +192,7 @@ module TBD
           next unless sss.outsideBoundaryCondition.downcase == "outdoors"
           next     if sss.construction.empty?
           next     if sss.construction.get.to_LayeredConstruction.empty?
+
           c         = sss.construction.get.to_LayeredConstruction.get
           i         = c.nameString
 
@@ -947,7 +953,7 @@ module TBD
       model  = "* modèle : #{ua[:file]}"       if ua.key?(:file)  && lang == :fr
       model += " (v#{ua[:version]})"           if ua.key?(:version)
       report << model                      unless model.empty?
-      report << "* TBD : v3.0.3"
+      report << "* TBD : v3.1.0"
       report << "* date : #{ua[:date]}"
 
       if lang == :en

--- a/lib/tbd/psi.rb
+++ b/lib/tbd/psi.rb
@@ -205,7 +205,7 @@ module TBD
         rimjoist:      0.300, # *
         parapet:       0.325, # *
         fenestration:  0.200, # *
-        corner:        0.300, # ** "regular (BETBG)", adj. for ext. dimensions
+        corner:        0.300, # ** not explicitely stated
         balcony:       0.500, # *
         party:         0.450, # *
         grade:         0.450, # *
@@ -219,7 +219,7 @@ module TBD
         rimjoist:      0.850, # *
         parapet:       0.800, # *
         fenestration:  0.500, # *
-        corner:        0.850, # ** ... not stated
+        corner:        0.850, # ** not explicitely stated
         balcony:       1.000, # *
         party:         0.850, # *
         grade:         0.850, # *
@@ -569,16 +569,21 @@ module TBD
     return mismatch("argh", s, Hash, mth, DBG, ipt)      unless argh.is_a?(Hash)
     return hashkey("argh", argh, opt, mth, DBG, ipt)     unless argh.key?(opt)
 
-    argh[:io_path]     = nil unless argh.key?(:io_path)
+    argh[:io_path    ] = nil unless argh.key?(:io_path)
     argh[:schema_path] = nil unless argh.key?(:schema_path)
-    pth = argh[:io_path]
+
+    pth = argh[:io_path    ]
     sch = argh[:schema_path]
 
-    if pth
-      return empty("JSON file", mth, FTL, ipt) unless File.size?(pth)
-      io = File.read(pth)
-      io = JSON.parse(io, symbolize_names: true)
-      return mismatch("io", io, Hash, mth, FTL, ipt) unless io.is_a?(Hash)
+    if pth && (pth.is_a?(String) || pth.is_a?(Hash))
+      if pth.is_a?(Hash)
+        io = pth
+      else
+        return empty("JSON file", mth, FTL, ipt) unless File.size?(pth)
+        io = File.read(pth)
+        io = JSON.parse(io, symbolize_names: true)
+        return mismatch("io", io, Hash, mth, FTL, ipt) unless io.is_a?(Hash)
+      end
 
       # Schema validation is not yet supported in the OpenStudio Application.
       # We nonetheless recommend that users rely on the json-schema gem, or an

--- a/lib/tbd/ua.rb
+++ b/lib/tbd/ua.rb
@@ -62,30 +62,33 @@ module TBD
     return zero("'#{id}': net area (m2)", mth, ERR, res)      unless area > TOL
 
     # First, calculate initial layer RSi to initially meet Ut target.
-    rt    = 1 / ut                      #                 target construction Rt
-    ro    = rsi(lc, film)               #                current construction Ro
-    new_r = lyr[:r] + (rt - ro)         #              new, un-derated layer RSi
-    new_u = 1 / new_r
+    rt     = 1 / ut                      #                target construction Rt
+    ro     = rsi(lc, film)               #               current construction Ro
+    new_r  = lyr[:r] + (rt - ro)         #             new, un-derated layer RSi
+    new_u  = 1 / new_r
 
     # Then, uprate (if possible) to counter expected thermal bridging effects.
-    u_psi = hloss / area                #                         from psi & khi
-    new_u = new_u - u_psi               # uprated layer USi to counter psi & khi
-    new_r = 1 / new_u                   # uprated layer RSi to counter psi & khi
+    u_psi  = hloss / area               #                         from psi & khi
+    new_u -= u_psi                      # uprated layer USi to counter psi & khi
+    new_r  = 1 / new_u                  # uprated layer RSi to counter psi & khi
 
     return zero("'#{id}': new Rsi", mth, ERR, res)          unless new_r > 0.001
-    loss  = 0.0                         # residual heatloss (not assigned) [W/K]
+
+    loss   = 0.0                        # residual heatloss (not assigned) [W/K]
 
     if lyr[:type] == :massless
       m     = lc.getLayer(lyr[:index]).to_MasslessOpaqueMaterial
       return  invalid("'#{id}' massless layer?", mth, 0)             if m.empty?
+
       m     = m.get.clone(model).to_MasslessOpaqueMaterial.get
               m.setName("#{id} uprated")
       new_r = 0.001                                         unless new_r > 0.001
       loss  = (new_u - 1 / new_r) * area                    unless new_r > 0.001
               m.setThermalResistance(new_r)
     else                                                     # type == :standard
-      m       = lc.getLayer(lyr[:index]).to_StandardOpaqueMaterial
+      m     = lc.getLayer(lyr[:index]).to_StandardOpaqueMaterial
       return  invalid("'#{id}' standard layer?", mth, 0)             if m.empty?
+
       m     = m.get.clone(model).to_StandardOpaqueMaterial.get
               m.setName("#{id} uprated")
       k     = m.thermalConductivity
@@ -108,10 +111,12 @@ module TBD
 
       ok = m.setThickness(d)
       return invalid("Can't uprate '#{id}': > 3m", mth, 0, ERR, res)   unless ok
+
       m.setThermalConductivity(k)                                          if ok
     end
 
     return invalid("", mth, 0, ERR, res) unless m
+
     lc.setLayer(lyr[:index], m)
     uo = 1 / rsi(lc, film)
 
@@ -187,6 +192,7 @@ module TBD
           next unless sss.outsideBoundaryCondition.downcase == "outdoors"
           next     if sss.construction.empty?
           next     if sss.construction.get.to_LayeredConstruction.empty?
+
           c         = sss.construction.get.to_LayeredConstruction.get
           i         = c.nameString
 
@@ -947,7 +953,7 @@ module TBD
       model  = "* modèle : #{ua[:file]}"       if ua.key?(:file)  && lang == :fr
       model += " (v#{ua[:version]})"           if ua.key?(:version)
       report << model                      unless model.empty?
-      report << "* TBD : v3.0.3"
+      report << "* TBD : v3.1.0"
       report << "* date : #{ua[:date]}"
 
       if lang == :en

--- a/lib/tbd/version.rb
+++ b/lib/tbd/version.rb
@@ -21,5 +21,5 @@
 # SOFTWARE.
 
 module TBD
-  VERSION = "3.0.3".freeze
+  VERSION = "3.1.0".freeze
 end


### PR DESCRIPTION
TBD users (e.g. measure users, gem-based scripts) could only customize TBD inputs with JSON files. These changes allows TBD to process the same JSON content directly as an input Hash. Better for scripted batch runs.