### PR TITLE
Extend support to ruby 3.x

### DIFF
--- a/tbd.gemspec
+++ b/tbd.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.bindir                   = "exe"
   s.require_paths            = ["lib"]
   s.executables              = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  s.required_ruby_version    = [">= 2.5.0", "< 3"]
+  s.required_ruby_version    = [">= 2.5.0", "< 4"]
   s.metadata                 = {}
 
   s.add_dependency             "topolys",     "~> 0"


### PR DESCRIPTION
Next OpenStudio SDK version will be ruby 3.2.2, so we need to be able to build against it

Similar PRs:
* https://github.com/rd2/oslg/pull/14
* https://github.com/rd2/osut/pull/19

@brgix  I'd be grateful if you could release a new version with these asap, it's going to remove some of pain of packaging it for us.