### PR TITLE
Update json_schema to at least 4 (where they added ruby 3.2 to the CI matrix)

### DIFF
--- a/tbd.gemspec
+++ b/tbd.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency             "topolys",     "~> 0"
   s.add_dependency             "osut",        "~> 0"
-  s.add_dependency             "json-schema", "~> 2.7.0"
+  s.add_dependency             "json-schema", "~> 4"
 
   s.add_development_dependency "bundler",     "~> 2.1"
   s.add_development_dependency "rake",        "~> 13.0"


### PR DESCRIPTION
https://rubygems.org/gems/json-schema/versions

[4.3.0](https://rubygems.org/gems/json-schema/versions/4.3.0) - March 26, 2024 (32 KB)
[4.2.0](https://rubygems.org/gems/json-schema/versions/4.2.0) - March 15, 2024 (32 KB)
[4.1.1](https://rubygems.org/gems/json-schema/versions/4.1.1) - September 15, 2023 (32 KB)
[4.1.0](https://rubygems.org/gems/json-schema/versions/4.1.0) - September 15, 2023 (32 KB)
[4.0.0](https://rubygems.org/gems/json-schema/versions/4.0.0) - April 24, 2023 (31.5 KB)
[3.0.0](https://rubygems.org/gems/json-schema/versions/3.0.0) - May 03, 2022 (31.5 KB)
[2.8.1](https://rubygems.org/gems/json-schema/versions/2.8.1) - October 14, 2018 (31 KB)
[2.8.0](https://rubygems.org/gems/json-schema/versions/2.8.0) - February 07, 2017 (29.5 KB)
[2.7.0](https://rubygems.org/gems/json-schema/versions/2.7.0) - September 29, 2016 (29.5 KB)