### PR TITLE
Pulls OSut v0.8.1 patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
-gem "osut", git: "https://github.com/rd2/osut", branch: "reset_uo"
-
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem "osut", git: "https://github.com/rd2/osut", branch: "reset_uo"
+
 gemspec

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/measures/tbd/LICENSE.md
+++ b/lib/measures/tbd/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/measures/tbd/measure.rb
+++ b/lib/measures/tbd/measure.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/measures/tbd/measure.xml
+++ b/lib/measures/tbd/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>tbd_measure</name>
   <uid>8890787b-8c25-4dc8-8641-b6be1b6c2357</uid>
-  <version_id>0e1528a0-a176-4d46-82d9-d2da40c0abd7</version_id>
-  <version_modified>2025-09-11T11:27:14Z</version_modified>
+  <version_id>627e5bb3-22a5-45ee-a9e6-e8ea9ccdfebc</version_id>
+  <version_modified>2026-01-03T18:23:09Z</version_modified>
   <xml_checksum>99772807</xml_checksum>
   <class_name>TBDMeasure</class_name>
   <display_name>Thermal Bridging and Derating - TBD</display_name>
@@ -464,7 +464,7 @@
       <filename>LICENSE.md</filename>
       <filetype>md</filetype>
       <usage_type>license</usage_type>
-      <checksum>3EBCA5DB</checksum>
+      <checksum>98D54646</checksum>
     </file>
     <file>
       <filename>README.md</filename>
@@ -493,13 +493,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>3FBDA0C2</checksum>
+      <checksum>489D7CFA</checksum>
     </file>
     <file>
       <filename>geo.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>5AB24CFB</checksum>
+      <checksum>9CA80CEB</checksum>
     </file>
     <file>
       <filename>geometry.rb</filename>
@@ -523,7 +523,7 @@
       <filename>psi.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>29905280</checksum>
+      <checksum>B9FB5E02</checksum>
     </file>
     <file>
       <filename>tbd.rb</filename>
@@ -541,13 +541,13 @@
       <filename>ua.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>0CC24D82</checksum>
+      <checksum>001D518B</checksum>
     </file>
     <file>
       <filename>utils.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>6940D006</checksum>
+      <checksum>BDF50D67</checksum>
     </file>
     <file>
       <filename>version.rb</filename>
@@ -565,7 +565,7 @@
       <filename>tbd_tests.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>9C76CD98</checksum>
+      <checksum>90CE962F</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/tbd/measure.xml
+++ b/lib/measures/tbd/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>tbd_measure</name>
   <uid>8890787b-8c25-4dc8-8641-b6be1b6c2357</uid>
-  <version_id>c8c77d7e-98ab-4e09-89d5-a9bf221c59b6</version_id>
-  <version_modified>2026-01-03T18:50:10Z</version_modified>
+  <version_id>8649cb7e-2e58-4a6d-ba67-911b6e0a41a6</version_id>
+  <version_modified>2026-01-04T12:08:45Z</version_modified>
   <xml_checksum>99772807</xml_checksum>
   <class_name>TBDMeasure</class_name>
   <display_name>Thermal Bridging and Derating - TBD</display_name>
@@ -541,7 +541,7 @@
       <filename>ua.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>001D518B</checksum>
+      <checksum>69C2A886</checksum>
     </file>
     <file>
       <filename>utils.rb</filename>

--- a/lib/measures/tbd/measure.xml
+++ b/lib/measures/tbd/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>tbd_measure</name>
   <uid>8890787b-8c25-4dc8-8641-b6be1b6c2357</uid>
-  <version_id>627e5bb3-22a5-45ee-a9e6-e8ea9ccdfebc</version_id>
-  <version_modified>2026-01-03T18:23:09Z</version_modified>
+  <version_id>c8c77d7e-98ab-4e09-89d5-a9bf221c59b6</version_id>
+  <version_modified>2026-01-03T18:50:10Z</version_modified>
   <xml_checksum>99772807</xml_checksum>
   <class_name>TBDMeasure</class_name>
   <display_name>Thermal Bridging and Derating - TBD</display_name>
@@ -529,7 +529,7 @@
       <filename>tbd.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>9E26251E</checksum>
+      <checksum>3919B9B0</checksum>
     </file>
     <file>
       <filename>transformation.rb</filename>

--- a/lib/measures/tbd/resources/geo.rb
+++ b/lib/measures/tbd/resources/geo.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/measures/tbd/resources/psi.rb
+++ b/lib/measures/tbd/resources/psi.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/measures/tbd/resources/tbd.rb
+++ b/lib/measures/tbd/resources/tbd.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/measures/tbd/resources/ua.rb
+++ b/lib/measures/tbd/resources/ua.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/measures/tbd/resources/ua.rb
+++ b/lib/measures/tbd/resources/ua.rb
@@ -1000,7 +1000,7 @@ module TBD
       model  = "* modèle : #{ua[:file]}"    if ua.key?(:file)  && lang == :fr
       model += " (v#{ua[:version]})"        if ua.key?(:version)
       report << model                   unless model.empty?
-      report << "* TBD : v3.5.0"
+      report << "* TBD : v3.5.1"
       report << "* date : #{ua[:date]}"
 
       if lang == :en

--- a/lib/measures/tbd/tests/tbd_tests.rb
+++ b/lib/measures/tbd/tests/tbd_tests.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/tbd.rb
+++ b/lib/tbd.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/tbd/geo.rb
+++ b/lib/tbd/geo.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/tbd/psi.rb
+++ b/lib/tbd/psi.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/tbd/ua.rb
+++ b/lib/tbd/ua.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/tbd/ua.rb
+++ b/lib/tbd/ua.rb
@@ -1000,7 +1000,7 @@ module TBD
       model  = "* modèle : #{ua[:file]}"    if ua.key?(:file)  && lang == :fr
       model += " (v#{ua[:version]})"        if ua.key?(:version)
       report << model                   unless model.empty?
-      report << "* TBD : v3.5.0"
+      report << "* TBD : v3.5.1"
       report << "* date : #{ua[:date]}"
 
       if lang == :en

--- a/lib/tbd/version.rb
+++ b/lib/tbd/version.rb
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2025 Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2026 Denis Bourgeois & Dan Macumber
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,5 +21,5 @@
 # SOFTWARE.
 
 module TBD
-  VERSION = "3.5.0".freeze
+  VERSION = "3.5.1".freeze
 end

--- a/tbd.gemspec
+++ b/tbd.gemspec
@@ -29,10 +29,9 @@ Gem::Specification.new do |s|
   s.metadata                 = {}
 
   s.add_dependency             "topolys",     "~> 0"
-  # s.add_dependency             "osut",        "~> 0.8.0"
+  s.add_dependency             "osut",        "~> 0.8.1"
   s.add_dependency             "json-schema", "~> 4"
 
-  s.add_development_dependency "osut",        "~> 0.8.1"
   s.add_development_dependency "bundler",     "~> 2.1"
   s.add_development_dependency "rake",        "~> 13.0"
   s.add_development_dependency "rspec",       "~> 3.11"

--- a/tbd.gemspec
+++ b/tbd.gemspec
@@ -29,9 +29,10 @@ Gem::Specification.new do |s|
   s.metadata                 = {}
 
   s.add_dependency             "topolys",     "~> 0"
-  s.add_dependency             "osut",        "~> 0.8.0"
+  # s.add_dependency             "osut",        "~> 0.8.0"
   s.add_dependency             "json-schema", "~> 4"
 
+  s.add_development_dependency "osut",        "~> 0.8.1"
   s.add_development_dependency "bundler",     "~> 2.1"
   s.add_development_dependency "rake",        "~> 13.0"
   s.add_development_dependency "rspec",       "~> 3.11"


### PR DESCRIPTION
Validates update to _OSut_ patch 0.8.1 (see [PR](https://github.com/rd2/osut/pull/26)).

An effort to harmonize _pyOSut_ and _OSut_ approaches when [resetting](https://github.com/rd2/osut/pull/26) a layered construction's _insulating_ layer. In principle, this is a benign change for TBD - no change in results or API calls. But a tad safer ...